### PR TITLE
Support Caqti 3.0.0

### DIFF
--- a/dream.opam
+++ b/dream.opam
@@ -50,8 +50,8 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
+  "caqti" {>= "3.0.0"}
+  "caqti-lwt" {>= "3.0.0"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.

--- a/example/h-sql/README.md
+++ b/example/h-sql/README.md
@@ -121,7 +121,7 @@ file:
 [`sql.opam`](https://github.com/camlworks/dream/blob/master/example/h-sql/esy.json):
 
 <pre>depends: [
-  <b>"caqti-driver-sqlite3" {>= "1.7.0"}</b>
+  <b>"caqti-driver-sqlite3"</b>
   "ocaml" {>= "4.08.0"}
   "dream"
   "dune" {>= "2.0.0"}

--- a/example/h-sql/README.md
+++ b/example/h-sql/README.md
@@ -9,22 +9,21 @@ a library for talking to SQL databases:
 
 ```ocaml
 module type DB = Caqti_lwt.CONNECTION
-module T = Caqti_type
 
 let list_comments =
   let query =
-    let open Caqti_request.Infix in
-    (T.unit ->* T.(t2 int string))
-    "SELECT id, text FROM comment" in
+    let open Caqti.Templater in
+    static T.(unit -->* t2 int string)
+      "SELECT id, text FROM comment" in
   fun (module Db : DB) ->
     let%lwt comments_or_error = Db.collect_list query () in
     Caqti_lwt.or_fail comments_or_error
 
 let add_comment =
   let query =
-    let open Caqti_request.Infix in
-    (T.string ->. T.unit)
-    "INSERT INTO comment (text) VALUES ($1)" in
+    let open Caqti.Templater in
+    static T.(string -->. unit)
+      "INSERT INTO comment (text) VALUES ($1)" in
   fun text (module Db : DB) ->
     let%lwt unit_or_error = Db.exec query text in
     Caqti_lwt.or_fail unit_or_error
@@ -134,17 +133,18 @@ file:
 Pass multiple arguments with `(?, ?, ..)`.  See [Caqti utop](https://ocaml.org/p/caqti/latest#running-under-utop).
 
 Tips.
-- `->.` returns a unit and uses `Db.exec`.
-- `->!` returns a single row and uses `Db.find`.
-- `->*` returns a list of rows and uses `Db.collect_list`.
+- `-->.` returns a unit and uses `Db.exec`.
+- `-->!` returns a single row and uses `Db.find`.
+- `-->?` returns zero or one row and uses `Db.find_opt`.
+- `-->*` returns a list of rows and uses `Db.collect_list`.
 
 Here is another example. We expect a single integer to be returned, which is the id of the created row. see [RETURNING sql tutorial](https://www.sqlitetutorial.net/sqlite-returning/).
 ```ocaml
 let add_session =
   let query =
-    let open Caqti_request.Infix in
-    ( T.(t4 string string float string) ->! T.int )
-    ("INSERT INTO dream_session(id, label, expires_at, payload) VALUES (?, ?, ?, ?) RETURNING id") in
+    let open Caqti.Templater in
+    static T.(t4 string string float string -->! int)
+      "INSERT INTO dream_session(id, label, expires_at, payload) VALUES (?, ?, ?, ?) RETURNING id" in
   fun (id, label, expires_at, payload) (module Db : DB) ->
     let%lwt unit_or_error = Db.find query (id, label, expires_at, payload) in
     Caqti_lwt.or_fail unit_or_error
@@ -152,11 +152,11 @@ let add_session =
 
 See
 
-- [`Caqti_response`](https://ocaml.org/p/caqti/latest/doc/Caqti_connection_sig/module-type-S/index.html)
+- [`Caqti.Connection.S`](https://ocaml.org/p/caqti/latest/doc/caqti/Caqti/Connection/module-type-S/index.html)
   for Caqti's statement runners. These are the fields of the module `Db` in the example.
-- [`Caqti_request`](https://ocaml.org/p/caqti/latest/doc/Caqti_request/Infix/index.html#indep)
-  sets up prepared statements.
-- [`Caqti_type`](https://ocaml.org/p/caqti/latest/doc/Caqti_type/index.html) is
+- [`Caqti.Templater`](https://ocaml.org/p/caqti/latest/doc/caqti/Caqti/Templater/index.html)
+  sets up request templates with prepared statements.
+- [`Caqti.Template.Row_type`](https://ocaml.org/p/caqti/latest/doc/caqti/Caqti/Template/Row_type/index.html) is
   used to specify the types of statement arguments and results.
 
 <br>

--- a/example/h-sql/h-sql.opam
+++ b/example/h-sql/h-sql.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 
 depends: [
-  "caqti-driver-sqlite3" {>= "1.7.0"}
+  "caqti-driver-sqlite3"
   "ocaml" {>= "4.08.0"}
   "dream"
   "dune" {>= "2.0.0"}

--- a/example/h-sql/sql.eml.ml
+++ b/example/h-sql/sql.eml.ml
@@ -1,10 +1,9 @@
 module type DB = Caqti_lwt.CONNECTION
-module T = Caqti_type
 
 let list_comments =
   let query =
-    let open Caqti_request.Infix in
-    (T.unit ->* T.(t2 int string))
+    let open Caqti.Templater in
+    static T.(unit -->* t2 int string)
     "SELECT id, text FROM comment" in
   fun (module Db : DB) ->
     let%lwt comments_or_error = Db.collect_list query () in
@@ -12,8 +11,8 @@ let list_comments =
 
 let add_comment =
   let query =
-    let open Caqti_request.Infix in
-    (T.string ->. T.unit)
+    let open Caqti.Templater in
+    static T.(string -->. unit)
     "INSERT INTO comment (text) VALUES ($1)" in
   fun text (module Db : DB) ->
     let%lwt unit_or_error = Db.exec query text in

--- a/example/w-postgres/postgres.eml.ml
+++ b/example/w-postgres/postgres.eml.ml
@@ -1,11 +1,9 @@
 module type DB = Caqti_lwt.CONNECTION
-module R = Caqti_request
-module T = Caqti_type
 
 let list_comments =
   let query =
-    let open Caqti_request.Infix in
-    (T.unit ->* T.(t2 int string))
+    let open Caqti.Templater in
+    static T.(unit -->* t2 int string)
     "SELECT id, text FROM comment" in
   fun (module Db : DB) ->
     let%lwt comments_or_error = Db.collect_list query () in
@@ -13,8 +11,8 @@ let list_comments =
 
 let add_comment =
   let query =
-    let open Caqti_request.Infix in
-    (T.string ->. T.unit)
+    let open Caqti.Templater in
+    static T.(string -->. unit)
     "INSERT INTO comment (text) VALUES ($1)" in
   fun text (module Db : DB) ->
     let%lwt unit_or_error = Db.exec query text in

--- a/src/sql/session.ml
+++ b/src/sql/session.ml
@@ -115,7 +115,7 @@ let rec create db expires_at attempt =
   (* Assume that any exception is a PRIMARY KEY collision (extremely unlikely)
      and try a couple more times. *)
   match%lwt insert db session with
-  | exception Caqti_error.Exn _ when attempt <= 3 ->
+  | exception Caqti.Error.Exn _ when attempt <= 3 ->
     create db expires_at (attempt + 1)
   | () ->
     Lwt.return session

--- a/src/sql/session.ml
+++ b/src/sql/session.ml
@@ -16,9 +16,6 @@ let (|>?) =
 
 module type DB = Caqti_lwt.CONNECTION
 
-module R = Caqti_request
-module T = Caqti_type
-
 let serialize_payload payload =
   payload
   |> List.map (fun (name, value) -> name, `String value)
@@ -27,8 +24,8 @@ let serialize_payload payload =
 
 let insert =
   let query =
-    let open Caqti_request.Infix in
-    (T.(t4 string string float string) ->. T.unit) {|
+    let open Caqti.Templater in
+    static T.(t4 string string float string -->. unit) {|
       INSERT INTO dream_session (id, label, expires_at, payload)
       VALUES ($1, $2, $3, $4)
     |} in
@@ -41,8 +38,8 @@ let insert =
 
 let find_opt =
   let query =
-    let open Caqti_request.Infix in
-    (T.string ->? T.(t3 string float string))
+    let open Caqti.Templater in
+    static T.(string -->? t3 string float string)
       "SELECT label, expires_at, payload FROM dream_session WHERE id = $1" in
 
   fun (module Db : DB) id ->
@@ -69,8 +66,8 @@ let find_opt =
 
 let refresh =
   let query =
-    let open Caqti_request.Infix in
-    (T.(t2 float string) ->. T.unit)
+    let open Caqti.Templater in
+    static T.(t2 float string -->. unit)
       "UPDATE dream_session SET expires_at = $1 WHERE id = $2" in
 
   fun (module Db : DB) (session : Session.session) ->
@@ -79,8 +76,8 @@ let refresh =
 
 let update =
   let query =
-    let open Caqti_request.Infix in
-    (T.(t2 string string) ->. T.unit)
+    let open Caqti.Templater in
+    static T.(t2 string string -->. unit)
       "UPDATE dream_session SET payload = $1 WHERE id = $2" in
 
   fun (module Db : DB) (session : Session.session) ->
@@ -90,8 +87,9 @@ let update =
 
 let remove =
   let query =
-    let open Caqti_request.Infix in
-    (T.string ->. T.unit) "DELETE FROM dream_session WHERE id = $1"  in
+    let open Caqti.Templater in
+    static T.(string -->. unit)
+      "DELETE FROM dream_session WHERE id = $1" in
 
   fun (module Db : DB) id ->
     let%lwt result = Db.exec query id in

--- a/src/sql/sql.ml
+++ b/src/sql/sql.ml
@@ -14,7 +14,7 @@ let log =
   Log.sub_log "dream.sql"
 
 (* TODO Debug metadata for the pools. *)
-let pool_field : (_, Caqti_error.t) Caqti_lwt_unix.Pool.t Message.field =
+let pool_field : (_, Caqti.Error.t) Caqti_lwt_unix.Pool.t Message.field =
   Message.new_field ()
 
 (* TODO This may not be necessary since Caqti 1.8.0. May require some messing
@@ -53,7 +53,7 @@ let sql_pool ?size ?post_connect uri =
       | Some f -> (fun db -> Lwt.map Result.ok (f db))
     in
     let pool =
-      let pool_config = Caqti_pool_config.create ?max_size:size () in
+      let pool_config = Caqti.Pool.Config.create ?max_size:size () in
       Caqti_lwt_unix.connect_pool ~pool_config ~post_connect parsed_uri
     in
     match pool with
@@ -66,7 +66,7 @@ let sql_pool ?size ?post_connect uri =
          debug handler. *)
       let message =
         Printf.sprintf "Dream.sql_pool: cannot create pool for '%s': %s"
-         uri (Caqti_error.show error) in
+         uri (Caqti.Error.show error) in
       log.error (fun log -> log ~request "%s" message);
       failwith message
   end

--- a/src/sql/sql.ml
+++ b/src/sql/sql.ml
@@ -17,19 +17,6 @@ let log =
 let pool_field : (_, Caqti.Error.t) Caqti_lwt_unix.Pool.t Message.field =
   Message.new_field ()
 
-(* TODO This may not be necessary since Caqti 1.8.0. May require some messing
-   around, "Enable foreign key constraint checks for SQLite3 starting at tweaks
-   version 1.8." in CHANGES. *)
-let foreign_keys_on =
-  let open Caqti_request.Infix in
-  (Caqti_type.unit ->. Caqti_type.unit) "PRAGMA foreign_keys = ON"
-  [@ocaml.warning "-3"]
-
-let standard_post_connect (module Db : Caqti_lwt.CONNECTION) =
-  match Caqti_driver_info.dialect_tag Db.driver_info with
-  | `Sqlite -> Db.exec foreign_keys_on ()
-  | _ -> Lwt.return (Ok ())
-
 let sql_pool ?size ?post_connect uri =
     let pool_cell = ref None in
     fun inner_handler request ->
@@ -48,13 +35,13 @@ let sql_pool ?size ?post_connect uri =
         "Dream.sql_pool: \
         'sqlite' is not a valid scheme; did you mean 'sqlite3'?");
     let post_connect =
-      match post_connect with
-      | None -> standard_post_connect
-      | Some f -> (fun db -> Lwt.map Result.ok (f db))
+      Option.map
+        (fun post_connect db -> Lwt.map Result.ok (post_connect db))
+        post_connect
     in
     let pool =
       let pool_config = Caqti.Pool.Config.create ?max_size:size () in
-      Caqti_lwt_unix.connect_pool ~pool_config ~post_connect parsed_uri
+      Caqti_lwt_unix.connect_pool ~pool_config ?post_connect parsed_uri
     in
     match pool with
     | Ok pool ->


### PR DESCRIPTION
Caqti 3.0.0 changes some module names and how requests are constructed. I've also removed a redundant `foreign_keys = ON` as that has been the default for some time (see https://github.com/paurkedal/ocaml-caqti/blob/5bc6e7a9450239c50ecdd126780272c54a98c062/caqti-driver-sqlite3/lib/caqti_driver_sqlite3.ml#L680).